### PR TITLE
Fix Tests for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - 3.8
           - 3.9
           - '3.10'
-          - 3.11
         include:
           - python-version: 3.6
             os: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - 3.8
           - 3.9
           - '3.10'
+          - 3.11
         include:
           - python-version: 3.6
             os: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,16 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: 
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
+        include:
+          - python-version: 3.6
+            os: ubuntu-20.04
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+          - '3.10'
         include:
           - python-version: 3.6
             os: ubuntu-20.04


### PR DESCRIPTION
Python 3.6 is no longer supported on latest ubuntu, causing the CI to fail.

This PR changes the CI setup so that:
- Python 3.6 is run on latest ubuntu supported (20.04)
- All other tests run on latest ubuntu

For more details: https://github.com/actions/setup-python/issues/544