### PR TITLE
GH-63: Fix use_vars task override with project setting

### DIFF
--- a/taskipy/task.py
+++ b/taskipy/task.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from taskipy.exceptions import MalformedTaskError
 
 
@@ -9,29 +11,31 @@ class Task:
         self.__task_use_vars = self.__extract_task_use_vars(task_toml_contents)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.__task_name
 
     @property
-    def command(self):
+    def command(self) -> str:
         return self.__task_command
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self.__task_description
 
     @property
-    def use_vars(self):
+    def use_vars(self) -> Optional[bool]:
         return self.__task_use_vars
 
-    def __extract_task_use_vars(self, task_toml_contents: object) -> bool:
+    def __extract_task_use_vars(self, task_toml_contents: object) -> Optional[bool]:
         if isinstance(task_toml_contents, str):
-            return False
+            return None
+
         if isinstance(task_toml_contents, dict):
-            value = task_toml_contents.get('use_vars', False)
-            if not isinstance(value, bool):
+            value = task_toml_contents.get('use_vars')
+            if value and not isinstance(value, bool):
                 raise MalformedTaskError(self.__task_name, f'task\'s "use_vars" arg has to be bool type got {type(value)}')
             return value
+
         raise MalformedTaskError(self.__task_name, 'tasks must be strings, or dicts that contain { cmd, help, use_vars }')
 
     def __extract_task_command(self, task_toml_contents: object) -> str:

--- a/taskipy/task.py
+++ b/taskipy/task.py
@@ -32,7 +32,7 @@ class Task:
 
         if isinstance(task_toml_contents, dict):
             value = task_toml_contents.get('use_vars')
-            if value and not isinstance(value, bool):
+            if value is not None and not isinstance(value, bool):
                 raise MalformedTaskError(self.__task_name, f'task\'s "use_vars" arg has to be bool type got {type(value)}')
             return value
 

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -134,8 +134,10 @@ class TaskRunner:
 
         return nonrecursive_vars, recursive_vars
 
-    def __format_task_command(self, task: Task, variables: Optional[dict]) -> str:
-        if task.use_vars or self.__project.settings.get('use_vars'):
+    def __format_task_command(self, task: Task, variables: dict) -> str:
+        if task.use_vars or (
+            task.use_vars is None and self.__project.settings.get('use_vars')
+        ):
             try:
                 return task.command.format(**variables)
             except KeyError as e:

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -554,6 +554,38 @@ class UseVarsTestCase(TaskipyTestCase):
         self.assertSubstr('hello John Doe :', stdout)
         self.assertEqual(exit_code, 0)
 
+    def test_use_vars_setting_override_to_false(self):
+        py_project_toml = '''
+            [tool.taskipy.settings]
+            use_vars = true
+
+            [tool.taskipy.variables]
+            name = "John Doe"
+
+            [tool.taskipy.tasks]
+            echo = { cmd = "echo hello {name}:", use_vars = false }
+        '''
+        cwd = self.create_test_dir_with_py_project_toml(py_project_toml)
+        exit_code, stdout, _ = self.run_task('echo', cwd=cwd)
+        self.assertSubstr('hello {name}:', stdout)
+        self.assertEqual(exit_code, 0)
+
+    def test_use_vars_setting_override_to_true(self):
+        py_project_toml = '''
+            [tool.taskipy.settings]
+            use_vars = false
+
+            [tool.taskipy.variables]
+            name = "John Doe"
+
+            [tool.taskipy.tasks]
+            echo = { cmd = "echo hello {name}:", use_vars = true }
+        '''
+        cwd = self.create_test_dir_with_py_project_toml(py_project_toml)
+        exit_code, stdout, _ = self.run_task('echo', cwd=cwd)
+        self.assertSubstr('hello John Doe:', stdout)
+        self.assertEqual(exit_code, 0)
+
 
 class RecursiveVariablesTestCase(TaskipyTestCase):
     def test_recursive_variables_can_use_other_variables(self):


### PR DESCRIPTION
Currently, the task-level `use_vars` override is not working when combined with the project setting because of how the task `use_vars` variable is being retrieved. It isn't making a distinction between `use_vars` being empty (and, therefore, should default to the project-level setting) and `use_vars` being explicitly set to `False` (and, therefore, should override the project-level setting). It is treating both as `False`.

This PR adds a third state, `None`, for the `use_vars` setting when it hasn't been explicitly set in the `pyproject.toml` file to allow making the distinction to implement this logic correctly.

Furthermore, it then handles this third state in accordance with the following table:

| use_vars task setting  | use_vars project setting | Result |
| ------------- | ------------- | ------- |
| None  | True  | True |
| None  | False  | False |
| True  | True  | True |
| True  | False  | True |
| False  | True  | False |
| False  | False  | False |

Essentially, the use_vars task-level setting takes priority if it is ever explicitly set. Otherwise, the project-level setting is used.

Closes #63 