### PR TITLE
add conda-forge badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 [![pypi](https://img.shields.io/pypi/v/taskipy?style=flat-square)](https://pypi.org/project/taskipy/)
 [![pypi-downloads](https://img.shields.io/pypi/dm/taskipy?style=flat-square)](https://pypi.org/project/taskipy/)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/taskipy.svg)](https://anaconda.org/conda-forge/taskipy)
 [![ci](https://img.shields.io/github/actions/workflow/status/taskipy/taskipy/ci.yml?style=flat-square)](https://github.com/taskipy/taskipy/actions/workflows/ci.yml)
 [![All Contributors](https://img.shields.io/github/all-contributors/illberoy/taskipy?color=orange&style=flat-square)](#contributors-)
 
@@ -71,6 +72,12 @@ To install taskipy as a dev dependency, simply run:
 
 ```bash
 poetry add --dev taskipy
+```
+
+For Anaconda Python-based environments, taskipy is also available via conda-forge:
+
+```bash
+conda install -c conda-forge taskipy
 ```
 
 ### Adding Tasks


### PR DESCRIPTION
Closes #56

The package is officially up on conda-forge! This PR adds the badge, so that users know about it.

I'll be pushing a PR there to manually synchronize the versions, but afterwards the conda-forge automated tools should keep the conda-forge package in sync with the PyPI version.

All the best,