### PR TITLE
Add release workflow on github release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: pip install setuptools==68.2.2 wheel==0.41.3 poetry==1.7.0 twine==4.0.2
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        poetry build
+        twine upload dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,10 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install dependencies
-      run: pip install setuptools==68.2.2 wheel==0.41.3 poetry==1.7.0 twine==4.0.2
+      run: pip install setuptools==68.2.2 wheel==0.41.3 poetry==1.7.1
     - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         poetry build
-        twine upload dist/*
+        poetry publish
+      env:
+        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release Python Package
 
 on:
   release:
-    types: [created]
+    types:
+      - published
 
 jobs:
   release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,16 +45,13 @@ lint = { cmd = "./task lint_pylint && ./task lint_mypy", help = "lint project wi
 lint_pylint = "pylint tests taskipy"
 lint_mypy = "mypy tests taskipy"
 
-publish = { cmd = "poetry publish --build", help = "publishes taskipy to PyPI as is. do not use directly" }
-post_publish = "./task make_release_commit"
-
 make_release_commit = { cmd = "python ./.hooks/make_release_commit.py", help = "creates a tagged commit for the release. do not use directly" }
 
 pre_publish_patch = "./task test"
-publish_patch = { cmd = "poetry version patch && ./task publish", help = "publishes a patch version, that has only fixes but no new features (x.x.PATCH)" }
+publish_patch = { cmd = "poetry version patch && ./task make_release_commit", help = "publishes a patch version, that has only fixes but no new features (x.x.PATCH)" }
 
 pre_publish_minor = "./task test"
-publish_minor = { cmd = "poetry version minor && ./task publish", help = "publishes a minor version, which has new fetures (x.MINOR.x)" }
+publish_minor = { cmd = "poetry version minor && ./task make_release_commit", help = "publishes a minor version, which has new features (x.MINOR.x)" }
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
This adds a workflow to Github Actions for creating a PyPI release when a GitHub release is created. The motivation for this is so that I would be able to handle #70.

In GitHub, this would require the `PYPI_TOKEN` secret being setup in the repository settings under Settings > Secrets and Variables > New Repository Secret.

This secret can be created via PyPI API Tokens: https://pypi.org/help/#apitoken. In particular, once the token is created:

> To use an API token:
>   Set your username to \_\_token\_\_
>   Set your password to the token value, including the pypi- prefix

Poetry uses a format of `POETRY_PYPI_TOKEN_<pypi repo name>` so `POETRY_PYPI_TOKEN_PYPI` is the PyPI token for the official PyPI repository: https://python-poetry.org/docs/repositories/#configuring-credentials. It seems it handles sending along the username of `__token__` for you.