### PR TITLE
Add feature to suggest similar tasks when a task is not found

### DIFF
--- a/taskipy/exceptions.py
+++ b/taskipy/exceptions.py
@@ -35,11 +35,14 @@ class MalformedPyProjectError(TaskipyError):
 class TaskNotFoundError(TaskipyError):
     exit_code = 127
 
-    def __init__(self, task_name: str):
+    def __init__(self, task_name: str, suggestion: Optional[str] = None):
         super().__init__()
         self.task = task_name
+        self.suggestion = suggestion
 
     def __str__(self):
+        if self.suggestion:
+            return f'could not find task "{self.task}", did you mean "{self.suggestion}"?'
         return f'could not find task "{self.task}"'
 
 class MalformedTaskError(TaskipyError):

--- a/taskipy/task_runner.py
+++ b/taskipy/task_runner.py
@@ -2,6 +2,7 @@ import sys
 import platform
 import signal
 import subprocess
+from difflib import get_close_matches
 from pathlib import Path
 from types import FrameType
 from typing import Callable, Dict, List, Tuple, Union, Optional
@@ -80,7 +81,12 @@ class TaskRunner:
         try:
             task = self.__project.tasks[task_name]
         except KeyError:
-            raise TaskNotFoundError(task_name)
+            suggestion = None
+            closest_match = get_close_matches(task_name, self.__project.tasks, n=1, cutoff=0.5)
+
+            if closest_match:
+                suggestion = closest_match[0]
+            raise TaskNotFoundError(task_name, suggestion)
 
         return pre_task, task, post_task
 

--- a/tests/fixtures/project_with_tasks_suggestion/pyproject.toml
+++ b/tests/fixtures/project_with_tasks_suggestion/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.poetry]
+name = "taskipy"
+description = "tasks runner for python projects"
+
+[tool.taskipy.tasks]
+exit_17 = "exit 17"
+print_hello_stdout = "echo 'hello stdout'"

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -320,7 +320,7 @@ class TaskRunFailTestCase(TaskipyTestCase):
 
         self.assertSubstr('could not find task "stdout", did you mean "print_hello_stdout"?', stdout)
         self.assertEqual(exit_code, 127)
-   
+
     def test_exiting_with_code_127_and_printing_if_task_not_found_and_suggestion(self):
         cwd = self.create_test_dir_from_fixture("project_with_tasks_suggestion")
         exit_code, stdout, _ = self.run_task("task_that_does_not_exist", cwd=cwd)

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -320,6 +320,13 @@ class TaskRunFailTestCase(TaskipyTestCase):
 
         self.assertSubstr('could not find task "stdout", did you mean "print_hello_stdout"?', stdout)
         self.assertEqual(exit_code, 127)
+   
+    def test_exiting_with_code_127_and_printing_if_task_not_found_and_suggestion(self):
+        cwd = self.create_test_dir_from_fixture("project_with_tasks_suggestion")
+        exit_code, stdout, _ = self.run_task("task_that_does_not_exist", cwd=cwd)
+
+        self.assertEqual('could not find task "task_that_does_not_exist"\n', stdout)
+        self.assertEqual(exit_code, 127)
 
     def test_exiting_with_code_127_and_printing_if_no_arg_is_passed(self):
         cwd = self.create_test_dir_from_fixture('project_with_pyproject_and_tasks')

--- a/tests/test_taskipy.py
+++ b/tests/test_taskipy.py
@@ -314,6 +314,13 @@ class TaskRunFailTestCase(TaskipyTestCase):
         self.assertSubstr('could not find task "task_that_does_not_exist"', stdout)
         self.assertEqual(exit_code, 127)
 
+    def test_exiting_with_code_127_and_printing_suggestion_if_task_not_found(self):
+        cwd = self.create_test_dir_from_fixture('project_with_tasks_suggestion')
+        exit_code, stdout, _ = self.run_task('stdout', cwd=cwd)
+
+        self.assertSubstr('could not find task "stdout", did you mean "print_hello_stdout"?', stdout)
+        self.assertEqual(exit_code, 127)
+
     def test_exiting_with_code_127_and_printing_if_no_arg_is_passed(self):
         cwd = self.create_test_dir_from_fixture('project_with_pyproject_and_tasks')
         executable_path = path.abspath('task')


### PR DESCRIPTION
Summary
---
This pull request implements one of the functionalities from issue #75, providing suggestions when a task is not found.

Details
---
Implemented a feature to suggest the most similar task if available when the user enters a task that does not exist.

Screenshots
---
![Capture d’écran du 2024-05-26 00-20-04](https://github.com/taskipy/taskipy/assets/91576261/ce066b06-4bc2-43d6-a0a5-2a3dde318f93)

